### PR TITLE
Excluded unnecessary directories for final ZIP archive

### DIFF
--- a/CmdMessenger/library.json
+++ b/CmdMessenger/library.json
@@ -3,6 +3,12 @@
   "keywords": "protocol, message, communication, serial",
   "description": "A serial messaging library for the Arduino and .NET/Mono platform",
   "include": "CmdMessenger",
+  "exclude":
+  [
+    "CSharp",
+    "Documentation",
+    "Tools"
+  ],
   "repository":
   {
     "type": "git",


### PR DESCRIPTION
PlatformIO Library Manager uses ``library.json`` to export necessary files into own ZIP archive. Then this archive will be used by ``platformio lib install`` command. 

I would ask you to exclude unnecessary content. For example, without excluding the size of this lib is equal ~12MB, with ``exclude`` field - ``several Kbytes``.

Thanks :)